### PR TITLE
Update submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "asn1_codec"]
 	path = asn1_codec
-	url = https://github.com/CDOT-CV/asn1_codec.git
+	url = https://github.com/usdot-jpo-ode/asn1_codec.git

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,21 @@
+# v2.0.2
+
+Use asn1_codec submodule from usdot repository.
+
+Linux library:
+[libasnapplication.so](https://github.com/neaeraconsulting/j2735-ffm-java/blob/v2.0.2/lib/libasnapplication.so)
+
+Windows library:
+[asnapplication.dll](https://github.com/neaeraconsulting/j2735-ffm-java/blob/v2.0.2/lib/asnapplication.dll)
+
+**Changelog**: https://github.com/neaeraconsulting/j2735-ffm-java/compare/v2.0.1...v2.0.2
+
+# v2.0.1
+
+Issues fixed in [internal review](https://github.com/neaeraconsulting/j2735-ffm-java/pull/2)
+
+**Changelog**: https://github.com/neaeraconsulting/j2735-ffm-java/compare/v2.0.0...v2.0.1
+
 # v2.0.0
 
 Refactor to use the existing C codec from asn1_codec, with a new C API, and backwards compatible Java API, except JER support is removed as noted below.

--- a/j2735-2024-ffm-lib/build.gradle
+++ b/j2735-2024-ffm-lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'usdot.jpo.ode'
-version = '2.0.1'
+version = '2.0.2'
 
 
 


### PR DESCRIPTION
Update the asn1_codec submodule to point to the usdot repo.

Adds release notes.

Bump version to 2.0.2